### PR TITLE
chore: update example for zipline v4

### DIFF
--- a/examples/zipline.iscu
+++ b/examples/zipline.iscu
@@ -4,6 +4,6 @@
 	"headers": {
 		"Authorization": "API_KEY",
 	},
-	"responseURL": "{{files[0]}}",
+	"responseURL": "{{files[0].url}}",
 	"fileFormName": "file"
 }


### PR DESCRIPTION
Zipline v4 released recently, they slightly changed the response format. Updating the example seems needed.

Since it's not documented yet on their end, this is the response:
```json
{
	"files": [{
		"id": "q0ms18cv620tj1970aj690cxs",
		"type": "image/png",
		"url": "https://example.org/u/example.png"
	}]
}
```