### PR TITLE
chore: bump Defaults to 9.0.3

### DIFF
--- a/ishare.xcodeproj/project.pbxproj
+++ b/ishare.xcodeproj/project.pbxproj
@@ -1088,7 +1088,7 @@
 			repositoryURL = "https://github.com/sindresorhus/Defaults";
 			requirement = {
 				kind = exactVersion;
-				version = "9.0.0-beta.3";
+				version = 9.0.3;
 			};
 		};
 		3A2994712CFF79CB0079CBB8 /* XCRemoteSwiftPackageReference "KeyboardShortcuts" */ = {

--- a/ishare/Config.xcconfig
+++ b/ishare/Config.xcconfig
@@ -5,5 +5,5 @@
 //  Created by Adrian Castro on 06.08.23.
 //
 
-BUILD_NUMBER = 62
-VERSION = 4.2.1
+BUILD_NUMBER = 63
+VERSION = 4.2.2


### PR DESCRIPTION
This PR bumps the dependency Defaults to version 9.0.3 to fix compatibility issues with Swift 6.