### PR TITLE
Fix German localization typos

### DIFF
--- a/ishare/Localizable.xcstrings
+++ b/ishare/Localizable.xcstrings
@@ -399,7 +399,7 @@
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Aufnhemen"
+            "value" : "Aufnehmen"
           }
         },
         "es" : {
@@ -655,7 +655,7 @@
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Bildschirm Aufnhemen:"
+            "value" : "Bildschirm Aufnehmen:"
           }
         },
         "es" : {


### PR DESCRIPTION
## Summary
Fixes #144

This PR corrects typos in the German localization:

- **Capture**: `Aufnhemen` → `Aufnehmen`
- **Capture Screen:**: `Bildschirm Aufnhemen:` → `Bildschirm Aufnehmen:`

The issue was a missing 'e' in 'Aufnehmen' (the German word for 'capture/record').

## Testing
- Verified the changes appear correctly in the localization file
- The fix is a simple string replacement with no behavioral changes