### PR TITLE
feat: add option to copy image data to clipboard instead of URL

### DIFF
--- a/ishare/Capture/ImageCapture.swift
+++ b/ishare/Capture/ImageCapture.swift
@@ -65,7 +65,11 @@ func captureScreen(type: CaptureType, display: Int = 1) async {
     if copyToClipboard {
         let pasteboard = NSPasteboard.general
         pasteboard.clearContents()
-        pasteboard.setString(fileURL.absoluteString, forType: .fileURL)
+        if Defaults[.copyImageToClipboard], let image = NSImage(contentsOf: fileURL) {
+            pasteboard.writeObjects([image])
+        } else {
+            pasteboard.setString(fileURL.absoluteString, forType: .fileURL)
+        }
     }
 
     if openInFinder {

--- a/ishare/Http/Custom.swift
+++ b/ishare/Http/Custom.swift
@@ -148,9 +148,11 @@ private func handleResponse(
         let historyItem = HistoryItem(fileUrl: fileUrl.absoluteString, deletionUrl: deletionUrl)
         addToUploadHistory(historyItem)
 
-        let pasteboard = NSPasteboard.general
-        pasteboard.clearContents()
-        pasteboard.setString(fileUrl.absoluteString, forType: .string)
+        if !Defaults[.copyImageToClipboard] {
+            let pasteboard = NSPasteboard.general
+            pasteboard.clearContents()
+            pasteboard.setString(fileUrl.absoluteString, forType: .string)
+        }
         callback?(nil, fileUrl)
     } else {
         callback?(CustomUploadError.responseParsing, nil)

--- a/ishare/Http/Imgur.swift
+++ b/ishare/Http/Imgur.swift
@@ -40,9 +40,11 @@ import SwiftyJSON
                     if let link = json["data"]["link"].string {
                         print("Image uploaded successfully. Link: \(link)")
 
-                        let pasteboard = NSPasteboard.general
-                        pasteboard.clearContents()
-                        pasteboard.setString(link, forType: .string)
+                        if !Defaults[.copyImageToClipboard] {
+                            let pasteboard = NSPasteboard.general
+                            pasteboard.clearContents()
+                            pasteboard.setString(link, forType: .string)
+                        }
 
                         let historyItem = HistoryItem(fileUrl: link)
                         addToUploadHistory(historyItem)

--- a/ishare/Util/Constants.swift
+++ b/ishare/Util/Constants.swift
@@ -41,6 +41,7 @@ extension KeyboardShortcuts.Name {
 extension Defaults.Keys {
     static let showMainMenu = Key<Bool>("showMainMenu", default: false, iCloud: true)
     static let copyToClipboard = Key<Bool>("copyToClipboard", default: true, iCloud: true)
+    static let copyImageToClipboard = Key<Bool>("copyImageToClipboard", default: false, iCloud: true)
     static let openInFinder = Key<Bool>("openInFinder", default: false, iCloud: true)
     static let saveToDisk = Key<Bool>("saveToDisk", default: true, iCloud: true)
     static let uploadMedia = Key<Bool>("uploadMedia", default: false, iCloud: true)

--- a/ishare/Views/SettingsMenuView.swift
+++ b/ishare/Views/SettingsMenuView.swift
@@ -103,6 +103,7 @@ struct GeneralSettingsView: View {
     @Default(.toastTimeout) var toastTimeout
     @Default(.aussieMode) var aussieMode
     @Default(.uploadHistory) var uploadHistory
+    @Default(.copyImageToClipboard) var copyImageToClipboard
 
     let appImage = NSImage(named: "AppIcon") ?? AppIcon
 
@@ -145,6 +146,7 @@ struct GeneralSettingsView: View {
                             Text("Launch at login".localized())
                         }
                         Toggle("Land down under".localized(), isOn: $aussieMode)
+                        Toggle("Copy image to clipboard instead of URL".localized(), isOn: $copyImageToClipboard)
                     }
 
                 VStack(alignment: .leading) {


### PR DESCRIPTION
Adds a `copyImageToClipboard` setting (off by default) that puts actual image data on the clipboard after a screenshot, instead of a file URL or upload URL. This way you can paste screenshots directly into Slack, Discord, Notes, etc. as inline images.

When enabled, upload handlers (Imgur/Custom) skip overwriting the clipboard with the URL so the image data is preserved.

**Changes:**
- `Constants.swift` — new `copyImageToClipboard` Defaults key
- `SettingsMenuView.swift` — toggle in General Settings
- `ImageCapture.swift` — write `NSImage` data to pasteboard when enabled
- `Imgur.swift` / `Custom.swift` — skip clipboard overwrite when enabled

Videos/recordings are unaffected by this setting.